### PR TITLE
Quartus support

### DIFF
--- a/src/apb_node_wrap.sv
+++ b/src/apb_node_wrap.sv
@@ -42,7 +42,9 @@ module apb_node_wrap #(
     logic [NB_MASTER-1:0]                     pready;
     logic [NB_MASTER-1:0]                     pslverr;
 
-    for (genvar i = 0; i < NB_MASTER; i++) begin
+    generate
+    genvar i;
+    for (i = 0; i < NB_MASTER; i++) begin : GEN_ASSIGN_MASTERS
         assign apb_masters[i].penable = penable[i];
         assign apb_masters[i].pwrite  = pwrite[i];
         assign apb_masters[i].paddr   = paddr[i];
@@ -52,6 +54,7 @@ module apb_node_wrap #(
         assign pready[i]              = apb_masters[i].pready;
         assign pslverr[i]             = apb_masters[i].pslverr;
     end
+    endgenerate
 
     apb_node #(
         .NB_MASTER      ( NB_MASTER         ),


### PR DESCRIPTION
In reference to: pulp-platform/pulpissimo#78

Fixed issues:

- `src/apb_node_wrap.sv`: [unnamed loop generate, genvar inside for loop definition](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#274-loop-generate-constructs-3)